### PR TITLE
Comments on wheel building script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,15 @@ install:
 script:
   - docker run --rm -v `pwd`:/io $DOCKER_IMAGE $PRE_CMD /io/travis/build-wheels.sh
   - ls wheelhouse/
+
+before_deploy:
+  - cd wheelhouse
+
+deploy:
+  provider: cloudfiles
+  username: travis-worker
+  api_key:
+      secure: "MoJpTnGSefkbtuoW6VbFx7Cn/FphcKVBGAHRpdvvlTqgXMhIVprkPyJm8SodEsdzB1a7OfsnDOeac9uvhc3IsGcChQrbnUXt3/943DFqDihEOrmb9LCrQ6nnS//bwqA//q4fgtC+nJH9Lpv8zyd5nrRFe9a0LmwCPglDA25gsNphvn5zTGhNqq3dfCsyoMlSpvextnjKU/H+os1ajt4m4Ev2iLpj1B55dqzj6O6UxrvXp8+nrTSyEx6b7U255yI9cIjMusDU8Y5ibnnPSU6Ee2NDwv5C/gxcUOGXYG46ux3lbuBvv2/D92jOifAR+T9QNq2UJK5LZhSWn5yUH1wn/XmjgTGy2nyZ5iKDvQw6UiU2Ku3/XGN7a5TzVRpdCln9HGpNR1HNw2b2+sKSwDYBlKke7G3EaepUKj9DIdvGaLEB3NXOv41K/+C+TbbbG7zpr9ISRox2oKEnQOC5HP1KYhXunvf7B3EvfjJLR9QkLZvzM9lmsehjPVvD37GmEQZjtWPuKTBJKsDllrPxX8HOuNVani75WsofaRgM9LRIW/s6k/J2qd88NZUwugtoH3SrGfvvWU6Sf5BI5nVcIR/pyfj3qbIkfWcY80i3rIIqZOiDwZ+2mQIRnx03cbvFkr2YUiAnazan+hZNj+VF9guU7eH6DM5KlUW1JuUZM0hwmAw="
+  region: ORD
+  container: wheels
+  skip_cleanup: true

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 set -e -x
 
-git clone https://github.com/pydata/pandas /io/pandas
-cd /io/pandas
+git clone https://github.com/pydata/pandas
+cd pandas
 git checkout v0.18.1
 
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if [[ ${PYBIN} != *"26"* ]] && [[ ${PYBIN} != *"33"* ]]; then
         echo "building for ${PYBIN}"
-        ${PYBIN}/pip install -r /io/pandas/ci/requirements_dev.txt
-        ${PYBIN}/pip wheel /io/pandas/ -w wheelhouse/
+        ${PYBIN}/pip install -r ci/requirements_dev.txt
+        ${PYBIN}/pip wheel --no-deps -w wheelhouse/ .
     else
         echo "skipping ${PYBIN}"
     fi


### PR DESCRIPTION
I think you actively don't want the pandas checkout to go into the host operating system, because you want the checkout to be a temporary copy that you will throw away with the building image.

The `--no-deps` flag avoids copying dependencies into the wheelhouse, such as numpy.
